### PR TITLE
Sort posts by date ascending

### DIFF
--- a/lib/posts.js
+++ b/lib/posts.js
@@ -21,9 +21,11 @@ export function getSortedPostsData() {
   });
   return allPostsData.sort((a, b) => {
     if (a.date < b.date) {
+      return -1;
+    } else if (a.date > b.date) {
       return 1;
     } else {
-      return -1;
+      return 0;
     }
   });
 }


### PR DESCRIPTION
## Summary
- switch post sorting to ascending order so the top page lists oldest posts first

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e6b15505c8332ada8d3eb62b6596c