### PR TITLE
Improve layout with simple styling

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import Head from 'next/head';
+
+export default function Layout({ children }) {
+  return (
+    <div className="container">
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <header className="header">
+        <Link href="/">
+          <h2 className="siteTitle">Java Articles</h2>
+        </Link>
+      </header>
+      <main>{children}</main>
+    </div>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/global.css';
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import Link from 'next/link';
 import { getSortedPostsData } from '../lib/posts';
+import Layout from '../components/Layout';
 
 export async function getStaticProps() {
   const allPostsData = getSortedPostsData();
@@ -13,20 +14,20 @@ export async function getStaticProps() {
 
 export default function Home({ allPostsData }) {
   return (
-    <div>
+    <Layout>
       <Head>
         <title>Java初心者向けサイト</title>
       </Head>
       <h1>Java初心者向け記事一覧</h1>
-      <ul>
+      <ul className="postList">
         {allPostsData.map(({ slug, title, date }) => (
-          <li key={slug}>
+          <li key={slug} className="postItem">
             <Link href={`/posts/${slug}`}>{title}</Link>
             <br />
             <small>{date}</small>
           </li>
         ))}
       </ul>
-    </div>
+    </Layout>
   );
 }

--- a/pages/posts/[slug].js
+++ b/pages/posts/[slug].js
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import { getAllPostSlugs, getPostData } from '../../lib/posts';
+import Layout from '../../components/Layout';
 
 export async function getStaticPaths() {
   const paths = getAllPostSlugs();
@@ -20,12 +21,14 @@ export async function getStaticProps({ params }) {
 
 export default function Post({ postData }) {
   return (
-    <div>
+    <Layout>
       <Head>
         <title>{postData.title}</title>
       </Head>
-      <h1>{postData.title}</h1>
-      <div dangerouslySetInnerHTML={{ __html: postData.contentHtml }} />
-    </div>
+      <article>
+        <h1>{postData.title}</h1>
+        <div dangerouslySetInnerHTML={{ __html: postData.contentHtml }} />
+      </article>
+    </Layout>
   );
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,0 +1,56 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
+    sans-serif;
+  background: #f8f9fa;
+  color: #333;
+}
+
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.header {
+  background: #1a73e8;
+  padding: 1rem;
+  margin-bottom: 2rem;
+  color: white;
+  text-align: center;
+}
+
+.siteTitle {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.postList {
+  list-style: none;
+  padding: 0;
+}
+
+.postItem {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-bottom: 1rem;
+  padding: 1rem;
+}
+
+.postItem a {
+  text-decoration: none;
+  color: #1a73e8;
+  font-weight: bold;
+}
+
+.postItem small {
+  color: #666;
+}
+
+article {
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
## Summary
- add global `_app.js` to load global CSS
- create `Layout` component with header
- update pages to use `Layout`
- add basic styling inspired by zenn

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e71879bf48332af12d6946f5a9c22