### PR TITLE
Update header color to green gradient

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -13,7 +13,8 @@ body {
 }
 
 .header {
-  background: #1a73e8;
+  /* Light green gradient similar to the provided screenshot */
+  background: linear-gradient(135deg, #c8f7dc 0%, #8bd3a9 100%);
   padding: 1rem;
   margin-bottom: 2rem;
   color: white;
@@ -22,7 +23,10 @@ body {
 
 .siteTitle {
   margin: 0;
-  font-size: 1.5rem;
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.15);
 }
 
 .postList {
@@ -40,7 +44,7 @@ body {
 
 .postItem a {
   text-decoration: none;
-  color: #1a73e8;
+  color: #4aa564;
   font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- use a light green gradient for the header
- enlarge site title font and add subtle text shadow
- change link color to match green theme

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686fa9690dd8833290d1aebde7510c8e