### PR TITLE
Add top margin to article titles

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -67,6 +67,11 @@ article {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+/* Add extra space above article titles */
+article h1 {
+  margin-top: 1rem;
+}
+
 /* Code block styling */
 .hljs {
   background: #000;


### PR DESCRIPTION
## Summary
- add CSS to create space above `<h1>` elements within articles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fb4fedfd88332990ce0d5d7dc452b