### PR TITLE
Show title image on top page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -18,7 +18,7 @@ export default function Home({ allPostsData }) {
       <Head>
         <title>VBA初心者向け記事一覧</title>
       </Head>
-      <h1>VBA初心者向け記事一覧</h1>
+      <img src="/title.png" alt="VBA初心者向け記事一覧" />
       <ul className="postList">
         {allPostsData.map(({ slug, title }) => (
           <li key={slug} className="postItem">


### PR DESCRIPTION
## Summary
- remove the heading text from the home page
- show `title.png` instead

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fba620a4083328fae3e765dbe1d7b